### PR TITLE
Handle cases where duplicate acm_certificates exist

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ data "aws_iam_server_certificate" "asg" {
 data "aws_acm_certificate" "asg" {
   count  = length(var.acm_certificate_domain) > 0 ? 1 - var.create_certificate : 0
   domain = var.acm_certificate_domain
+  most_recent = true
 }
 
 data "aws_elb_service_account" "main" {}


### PR DESCRIPTION
Handle cases where multiple acm_certificates with the same domain exist
by selecting the most_recent certificate