### PR TITLE
aws_alb_listener_rule role condition fix

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -318,8 +318,9 @@ resource "aws_alb_listener_rule" "http-ignore-rules" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = [element(var.ignore_paths, count.index)]
+    path_pattern{
+      values = [element(var.ignore_paths, count.index)]
+    }
   }
 }
 
@@ -339,8 +340,9 @@ resource "aws_alb_listener_rule" "https-ignore-rules" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = [element(var.ignore_paths, count.index)]
+    path_pattern{
+       values = [element(var.ignore_paths, count.index)]
+    }
   }
 }
 
@@ -360,8 +362,9 @@ resource "aws_alb_listener_rule" "redirect_paths" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = [element(var.redirect_paths, count.index).condition]
+    path_pattern {
+       values = [element(var.redirect_paths, count.index).condition]
+    }
   }
 }
 

--- a/storage.tf
+++ b/storage.tf
@@ -14,7 +14,6 @@ resource "aws_s3_bucket" "asg-logs" {
   }
 }
 
-
 provider "aws" {
   alias  = "s3provider"
   region = var.data_bucket_region


### PR DESCRIPTION
Terraform aws_alb_listener_rule fix

Error:
on ../../../modules/asg-base/network.tf line 342, in resource "aws_alb_listener_rule" "https-ignore-rules":
 342:     field  = "path-pattern"
An argument named "field" is not expected here.