### PR TITLE
Revert "Use "for_each" to loop through "domain_validation_options" (#6)"

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -253,25 +253,19 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
+  count      = var.create_certificate == 1 ? length(var.cnames) + 1 : 0
   depends_on = [aws_acm_certificate.cert]
-  name       = each.value.name
-  type       = each.value.type
+  name       = lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_name")
+  type       = lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_type")
   zone_id    = data.aws_route53_zone.primary[0].id
-  records    = [each.value.record]
+  records    = [lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_value")]
   ttl        = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
   count                   = var.create_certificate
   certificate_arn         = aws_acm_certificate.cert[count.index].arn
-  validation_record_fqdns = values(aws_route53_record.cert_validation)[*].fqdn
+  validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
 
   timeouts {
     create = "1h"


### PR DESCRIPTION
This reverts commit c56b7172bb645a4d7b8265040b46401b1c786a48.

We need to only do validations when we are creating a certificate.
In cases where we do not create a certificate this change fails.
```
Error: Invalid index

  on ./network.tf line 257, in resource "aws_route53_record" "cert_validation":
 257:     for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
    |----------------
    | aws_acm_certificate.cert is empty tuple

The given key does not identify an element in this collection value.
```