### PR TITLE
Convert 'domain_validation_options' to list before trying to retrieve a specific index

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -255,10 +255,10 @@ resource "aws_acm_certificate" "cert" {
 resource "aws_route53_record" "cert_validation" {
   count      = var.create_certificate == 1 ? length(var.cnames) + 1 : 0
   depends_on = [aws_acm_certificate.cert]
-  name       = lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_name")
-  type       = lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_type")
+  name       = lookup(element(tolist(aws_acm_certificate.cert[0].domain_validation_options[*]), count.index), "resource_record_name")
+  type       = lookup(element(tolist(aws_acm_certificate.cert[0].domain_validation_options[*]), count.index), "resource_record_type")
   zone_id    = data.aws_route53_zone.primary[0].id
-  records    = [lookup(aws_acm_certificate.cert[0].domain_validation_options[count.index], "resource_record_value")]
+  records    = [lookup(element(tolist(aws_acm_certificate.cert[0].domain_validation_options[*]), count.index), "resource_record_value")]
   ttl        = 60
 }
 


### PR DESCRIPTION
In the terraform aws provider v3.0.0 release the
'domain_validation_options' attribute has been converted to a set. A set
can not be indexed as such it must be converted to a list before trying
to retrieve a specific index from the object