### PR TITLE
Generate aws_route53_records only when "create_route53_records" is true

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -101,7 +101,7 @@ resource "aws_security_group" "asg_instance" {
 }
 
 resource "aws_route53_record" "asg" {
-  count   = length(var.service_domains)
+  count   = var.create_route53_records ? length(var.service_domains) : 0
   zone_id = data.aws_route53_zone.primary[var.service_domains[count.index]].zone_id
   name    = var.service_domains[count.index]
   type    = "A"
@@ -114,7 +114,7 @@ resource "aws_route53_record" "asg" {
 }
 
 resource "aws_route53_record" "asg-cnames" {
-  count   = length(var.cnames)
+  count   = var.create_route53_records ? length(var.cnames) : 0
   zone_id = data.aws_route53_zone.primary[element(var.cnames, count.index)].zone_id
   name    = element(var.cnames, count.index)
   type    = "CNAME"


### PR DESCRIPTION
# Changes

- Check if `create_route53_record` is true before creating `aws_route53_record` resources