### PR TITLE
Use `tolist` function instead of deprecated `list` function

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "target_group_arns" {
-  value = concat(list(aws_alb_target_group.http.arn), aws_alb_target_group.https.*.arn)
+  value = concat(tolist([aws_alb_target_group.http.arn]), aws_alb_target_group.https.*.arn)
 }
 
 output "security_groups" {


### PR DESCRIPTION
# Changes

- Use `tolist` instead of `list`. _The `list` function has been deprecated since v0.12 and has recently been [removed](https://www.terraform.io/docs/language/functions/list.html)._